### PR TITLE
Support receiving instances of parser/syntax/stringifier

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -13,15 +13,15 @@
  * @return {Object} options PostCSS Options
  */
 module.exports = function options (options) {
-  if (options.parser) {
+  if (options.parser && typeof options.parser === 'string') {
     options.parser = require(options.parser)
   }
 
-  if (options.syntax) {
+  if (options.syntax && typeof options.syntax === 'string') {
     options.syntax = require(options.syntax)
   }
 
-  if (options.stringifier) {
+  if (options.stringifier && typeof options.stringifier === 'string') {
     options.stringifier = require(options.stringifier)
   }
 


### PR DESCRIPTION
Don't attempt to require non-strings.

Supports a config that includes, say, `{ parser: require('sugarss') }` instead of `{ parser: 'sugarss' }`. This avoids module resolution problems, especially when symlinks are involved.