### PR TITLE
Add `logo.svg` to `.npmignore`.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@
 
 CHANGELOG.md
 CONTRIBUTING.md
+logo.svg
 README.md
 
 npm-debug.log


### PR DESCRIPTION
You could also consider just defining `files` in `package.json` to whitelist the files you want to publish.
Also, having `CHANGELOG.md` and `README.md` in `.npmignore` doesn't do anything, they're published regardless.